### PR TITLE
Hotfix: Fix Three.js import errors with code splitting

### DIFF
--- a/src/components/abacus/Abacus.js
+++ b/src/components/abacus/Abacus.js
@@ -1,44 +1,9 @@
 import React from 'react';
-import { Canvas } from '@react-three/fiber';
-import AbacusModel from './AbacusModel';
-import SimpleAbacus from './SimpleAbacus';
-import AbacusControls from './AbacusControls';
-import { useGameContext } from '../../context/GameContext';
-import '../../styles/Abacus.css';
+import AbacusLoader from './AbacusLoader';
 
-const Abacus = ({ onBeadChange }) => {
-  const { gameState } = useGameContext();
-  const { abacusState } = gameState;
-  
-  // Check if we should use the simple abacus
-  const useSimpleAbacus = process.env.REACT_APP_USE_SIMPLE_ABACUS === 'true';
-  
-  // If using simple abacus, return that component
-  if (useSimpleAbacus) {
-    return <SimpleAbacus onBeadChange={onBeadChange} />;
-  }
-  
-  // Otherwise, return the 3D abacus
-  return (
-    <div className="abacus-container">
-      <div className="abacus-canvas-container">
-        <Canvas
-          camera={{ position: [0, 4, 8], fov: 50 }}
-          shadows
-        >
-          <AbacusModel 
-            abacusState={abacusState}
-            onBeadChange={onBeadChange}
-          />
-        </Canvas>
-      </div>
-      
-      <AbacusControls 
-        abacusState={abacusState}
-        onBeadChange={onBeadChange}
-      />
-    </div>
-  );
+// This is just a simple wrapper around AbacusLoader for backward compatibility
+const Abacus = (props) => {
+  return <AbacusLoader {...props} />;
 };
 
 export default Abacus;

--- a/src/components/abacus/Abacus3D.js
+++ b/src/components/abacus/Abacus3D.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Canvas } from '@react-three/fiber';
+import AbacusModel from './AbacusModel';
+import AbacusControls from './AbacusControls';
+import { useGameContext } from '../../context/GameContext';
+import '../../styles/Abacus.css';
+
+const Abacus3D = ({ onBeadChange }) => {
+  const { gameState } = useGameContext();
+  const { abacusState } = gameState;
+
+  return (
+    <div className="abacus-container">
+      <div className="abacus-canvas-container">
+        <Canvas
+          camera={{ position: [0, 4, 8], fov: 50 }}
+          shadows
+        >
+          <AbacusModel 
+            abacusState={abacusState}
+            onBeadChange={onBeadChange}
+          />
+        </Canvas>
+      </div>
+      
+      <AbacusControls 
+        abacusState={abacusState}
+        onBeadChange={onBeadChange}
+      />
+    </div>
+  );
+};
+
+export default Abacus3D;

--- a/src/components/abacus/AbacusLoader.js
+++ b/src/components/abacus/AbacusLoader.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import SimpleAbacus from './SimpleAbacus';
+
+// Only import Three.js components if not using simple abacus
+const useSimpleAbacus = process.env.REACT_APP_USE_SIMPLE_ABACUS === 'true';
+
+// Create a component that conditionally loads the appropriate abacus
+const AbacusLoader = (props) => {
+  // For simplicity in production, always use the SimpleAbacus
+  if (useSimpleAbacus) {
+    return <SimpleAbacus {...props} />;
+  }
+  
+  // Dynamically import the 3D abacus only if needed
+  // This helps webpack to not include the 3D abacus code in the production build
+  // when REACT_APP_USE_SIMPLE_ABACUS is set to true
+  const Abacus = React.lazy(() => import('./Abacus3D'));
+  
+  return (
+    <React.Suspense fallback={<SimpleAbacus {...props} />}>
+      <Abacus {...props} />
+    </React.Suspense>
+  );
+};
+
+export default AbacusLoader;


### PR DESCRIPTION
## Hotfix: Fix Three.js Import Errors with Code Splitting

### Problem
The Heroku build is still failing with the error message:
```
Attempted import error: 'BatchedMesh' is not exported from 'three' (imported as 'THREE').
```

The previous fix wasn't enough because even with conditional rendering, webpack still includes all imports in the bundle.

### Solution
This PR takes a more robust approach using code splitting and dynamic imports:

1. Renamed `Abacus.js` to `Abacus3D.js` to clearly separate the 3D implementation
2. Created a new `AbacusLoader.js` component that:
   - Uses dynamic imports with React.lazy() for the 3D version
   - Statically imports only the 2D version (SimpleAbacus)
   - Checks the environment variable REACT_APP_USE_SIMPLE_ABACUS
   - Returns just the SimpleAbacus component when the env variable is true
   - Code-splits the 3D version to prevent it from being bundled when not needed
3. Updated `Abacus.js` to be a simple wrapper for backward compatibility

This approach ensures that when building with `REACT_APP_USE_SIMPLE_ABACUS=true` (which happens in the Heroku build), the Three.js code with the problematic import is entirely excluded from the bundle.

### Changes
- Added code splitting with React.lazy and Suspense
- Properly isolated the Three.js code to prevent bundling issues
- Maintained backward compatibility for components that use Abacus.js

This PR should fully resolve the Heroku deployment issue by preventing the problematic code from being included in the production bundle at all.
