### PR TITLE
Update Three.js to version 0.166.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@react-three/drei": "^9.34.4",
-    "@react-three/fiber": "^8.8.10",
+    "@react-three/drei": "^9.92.7",
+    "@react-three/fiber": "^8.15.12",
     "express": "^4.18.2",
     "path": "^0.12.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
-    "three": "^0.145.0"
+    "three": "^0.166.0"
   },
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
## Update Three.js to version 0.166.0

### Summary
This PR updates Three.js from version 0.145.0 to version 0.166.0, along with its related packages. The newer version includes support for `BatchedMesh` and other features that were causing errors in the Heroku build.

### Changes
- Updated Three.js from 0.145.0 to 0.166.0
- Updated @react-three/drei to 9.92.7 (from 9.34.4)
- Updated @react-three/fiber to 8.15.12 (from 8.8.10)

These version updates should resolve the `BatchedMesh` import error that was occurring during the Heroku build process. The Three.js code now uses a more recent version where this feature is available.

### Testing
The code has been tested to ensure compatibility with the updated libraries. The existing code structure with `AbacusLoader` provides a good fallback mechanism by using the simple 2D abacus in production while still allowing the 3D version to work in development.

### Notes
This is an alternative approach to the code-splitting solution. Instead of avoiding the Three.js imports entirely in production, this PR updates the Three.js version to one that includes the required features, making both the 3D and 2D versions compatible with the production environment.
