### PR TITLE
Fix Bătălia Abacului: Compară Numerele functionality

### DIFF
--- a/src/components/compare/CompareAbacus.js
+++ b/src/components/compare/CompareAbacus.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import AbacusControls from '../abacus/AbacusControls';
+import '../../styles/Abacus.css';
+
+/**
+ * A simplified 2D version of the abacus that accepts state directly via props
+ * instead of using the global context.
+ */
+const CompareAbacus = ({ abacusState, onBeadChange, showControls = true }) => {
+  // Colors for the beads
+  const beadColors = {
+    thousands: '#3498db', // Blue
+    hundreds: '#e74c3c',  // Red
+    tens: '#2ecc71',      // Green
+    units: '#9b59b6'      // Purple
+  };
+
+  // Labels for each column
+  const columnLabels = {
+    thousands: 'M', // Mii
+    hundreds: 'S',  // Sute
+    tens: 'Z',      // Zeci
+    units: 'U'      // Unități
+  };
+
+  // Function to render a column of beads with its label
+  const renderBeadColumn = (count, columnName, color, label) => {
+    const beads = [];
+    
+    // Add beads based on count
+    for (let i = 0; i < count; i++) {
+      beads.push(
+        <div 
+          key={`bead-${columnName}-${i}`}
+          className="bead"
+          style={{ backgroundColor: color }}
+          onClick={() => onBeadChange(columnName, count - 1)}
+        />
+      );
+    }
+    
+    // Add "slots" for remaining beads (up to 9)
+    for (let i = count; i < 9; i++) {
+      beads.push(
+        <div 
+          key={`empty-${columnName}-${i}`}
+          className="bead-slot"
+          onClick={() => onBeadChange(columnName, count + 1)}
+        />
+      );
+    }
+    
+    return (
+      <div className="bead-column-wrapper">
+        <div className="column-label" style={{ backgroundColor: color }}>
+          {label}
+        </div>
+        <div className="bead-column">
+          {beads}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="abacus-container">
+      <div className="simple-abacus">
+        <div className="abacus-frame">
+          <div className="bead-columns">
+            {renderBeadColumn(
+              abacusState.thousands, 
+              'thousands', 
+              beadColors.thousands, 
+              columnLabels.thousands
+            )}
+            {renderBeadColumn(
+              abacusState.hundreds, 
+              'hundreds', 
+              beadColors.hundreds, 
+              columnLabels.hundreds
+            )}
+            {renderBeadColumn(
+              abacusState.tens, 
+              'tens', 
+              beadColors.tens, 
+              columnLabels.tens
+            )}
+            {renderBeadColumn(
+              abacusState.units, 
+              'units', 
+              beadColors.units, 
+              columnLabels.units
+            )}
+          </div>
+        </div>
+      </div>
+      
+      {showControls && (
+        <AbacusControls 
+          abacusState={abacusState}
+          onBeadChange={onBeadChange}
+        />
+      )}
+    </div>
+  );
+};
+
+export default CompareAbacus;

--- a/src/components/compare/ComparisonControls.js
+++ b/src/components/compare/ComparisonControls.js
@@ -85,7 +85,6 @@ const ComparisonControls = ({
     if (currentComparison && currentComparison.result !== '=') {
       // We've found a difference, so we can stop comparing
       setAnalyzingComplete(true);
-      // Clear the highlighted place value
       onNextPlaceValue(null);
     } else {
       // Move to the next place value

--- a/src/components/compare/ComparisonControls.js
+++ b/src/components/compare/ComparisonControls.js
@@ -85,7 +85,7 @@ const ComparisonControls = ({
     if (currentComparison && currentComparison.result !== '=') {
       // We've found a difference, so we can stop comparing
       setAnalyzingComplete(true);
-      // Use the prop function instead of trying to set the state directly
+      // Clear the highlighted place value
       onNextPlaceValue(null);
     } else {
       // Move to the next place value

--- a/src/components/compare/ComparisonControls.js
+++ b/src/components/compare/ComparisonControls.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { 
   numberToPlaceValues, 
   getPlaceValueName, 
+  getPlaceValueLabel,
   findDifferingPlaceValue 
 } from '../../utils/compareNumbersUtils';
 import { 
@@ -12,33 +13,35 @@ import '../../styles/ComparisonControls.css';
 
 /**
  * Component for comparing numbers and selecting the right comparison operator
+ * 
+ * @param {Object} props
+ * @param {Function} props.onComparisonSelect - Handler for comparison operator selection
+ * @param {string} props.selectedOperator - Currently selected operator
+ * @param {string} props.highlightedPlaceValue - Currently highlighted place value
+ * @param {Function} props.onNextPlaceValue - Handler to move to next place value
+ * @param {Array} props.abacusStates - Current states of both abacuses
+ * @param {Array} props.numbers - Numbers being compared
  */
-const ComparisonControls = (props) => {
-  const { 
-    onComparisonSelect, 
-    selectedOperator,
-    highlightedPlaceValue,
-    onNextPlaceValue,
-    abacusStates,
-    numbers
-  } = props;
-  
+const ComparisonControls = ({ 
+  onComparisonSelect, 
+  selectedOperator,
+  highlightedPlaceValue,
+  onNextPlaceValue,
+  abacusStates,
+  numbers
+}) => {
   const [comparisonResult, setComparisonResult] = useState(null);
-  const [analysisFinished, setAnalysisFinished] = useState(false);
+  const [analyzingComplete, setAnalyzingComplete] = useState(false);
   const [placeValueComparisons, setPlaceValueComparisons] = useState({});
   const [showExplanation, setShowExplanation] = useState(false);
-  
-  // When we don't have a highlighted place value, we're done with analysis
-  useEffect(() => {
-    if (!highlightedPlaceValue) {
-      setAnalysisFinished(true);
-    }
-  }, [highlightedPlaceValue]);
   
   // When highlighted place value changes, analyze the comparison for that place
   useEffect(() => {
     if (highlightedPlaceValue) {
       analyzeHighlightedPlaceValue();
+    } else {
+      // If no highlighted place value, we're ready for selection
+      setAnalyzingComplete(true);
     }
   }, [highlightedPlaceValue, abacusStates]);
   
@@ -82,15 +85,11 @@ const ComparisonControls = (props) => {
     
     if (currentComparison && currentComparison.result !== '=') {
       // We've found a difference, so we can stop comparing
-      // Move to final state (null place value)
-      if (typeof onNextPlaceValue === 'function') {
-        onNextPlaceValue(null);
-      }
+      setAnalyzingComplete(true);
+      setHighlightedPlaceValue(null);
     } else {
       // Move to the next place value
-      if (typeof onNextPlaceValue === 'function') {
-        onNextPlaceValue();
-      }
+      onNextPlaceValue();
     }
   };
   
@@ -123,7 +122,7 @@ const ComparisonControls = (props) => {
       {highlightedPlaceValue ? (
         // Show the step-by-step analysis interface
         <div className="place-value-analysis">
-          <h3>Compară {getPlaceValueName(highlightedPlaceValue)}</h3>
+          <h3>Compară {getPlaceValueName(highlightedPlaceValue)} ({getPlaceValueLabel(highlightedPlaceValue)})</h3>
           
           <div className="place-value-comparison">
             <div className="comparison-value">
@@ -162,7 +161,7 @@ const ComparisonControls = (props) => {
             Continuă
           </button>
         </div>
-      ) : analysisFinished ? (
+      ) : analyzingComplete ? (
         // Show the operator selection interface
         <div className="operator-selection">
           <h3>Alege simbolul de comparare:</h3>

--- a/src/components/compare/ComparisonControls.js
+++ b/src/components/compare/ComparisonControls.js
@@ -85,7 +85,8 @@ const ComparisonControls = ({
     if (currentComparison && currentComparison.result !== '=') {
       // We've found a difference, so we can stop comparing
       setAnalyzingComplete(true);
-      setHighlightedPlaceValue(null);
+      // Use the prop function instead of trying to set the state directly
+      onNextPlaceValue(null);
     } else {
       // Move to the next place value
       onNextPlaceValue();

--- a/src/components/compare/ComparisonControls.js
+++ b/src/components/compare/ComparisonControls.js
@@ -12,35 +12,33 @@ import '../../styles/ComparisonControls.css';
 
 /**
  * Component for comparing numbers and selecting the right comparison operator
- * 
- * @param {Object} props
- * @param {Function} props.onComparisonSelect - Handler for comparison operator selection
- * @param {string} props.selectedOperator - Currently selected operator
- * @param {string} props.highlightedPlaceValue - Currently highlighted place value
- * @param {Function} props.onNextPlaceValue - Handler to move to next place value
- * @param {Array} props.abacusStates - Current states of both abacuses
- * @param {Array} props.numbers - Numbers being compared
  */
-const ComparisonControls = ({ 
-  onComparisonSelect, 
-  selectedOperator,
-  highlightedPlaceValue,
-  onNextPlaceValue,
-  abacusStates,
-  numbers
-}) => {
+const ComparisonControls = (props) => {
+  const { 
+    onComparisonSelect, 
+    selectedOperator,
+    highlightedPlaceValue,
+    onNextPlaceValue,
+    abacusStates,
+    numbers
+  } = props;
+  
   const [comparisonResult, setComparisonResult] = useState(null);
-  const [analyzingComplete, setAnalyzingComplete] = useState(false);
+  const [analysisFinished, setAnalysisFinished] = useState(false);
   const [placeValueComparisons, setPlaceValueComparisons] = useState({});
   const [showExplanation, setShowExplanation] = useState(false);
+  
+  // When we don't have a highlighted place value, we're done with analysis
+  useEffect(() => {
+    if (!highlightedPlaceValue) {
+      setAnalysisFinished(true);
+    }
+  }, [highlightedPlaceValue]);
   
   // When highlighted place value changes, analyze the comparison for that place
   useEffect(() => {
     if (highlightedPlaceValue) {
       analyzeHighlightedPlaceValue();
-    } else {
-      // If no highlighted place value, we're ready for selection
-      setAnalyzingComplete(true);
     }
   }, [highlightedPlaceValue, abacusStates]);
   
@@ -79,18 +77,20 @@ const ComparisonControls = ({
   
   // Handle clicking the "Continue" button to move to next place value
   const handleContinueAnalysis = () => {
-    if (!highlightedPlaceValue) return;
-    
     // First check if this place value already determined the result
     const currentComparison = placeValueComparisons[highlightedPlaceValue];
     
     if (currentComparison && currentComparison.result !== '=') {
       // We've found a difference, so we can stop comparing
-      setAnalyzingComplete(true);
-      onNextPlaceValue(null);
+      // Move to final state (null place value)
+      if (typeof onNextPlaceValue === 'function') {
+        onNextPlaceValue(null);
+      }
     } else {
       // Move to the next place value
-      onNextPlaceValue();
+      if (typeof onNextPlaceValue === 'function') {
+        onNextPlaceValue();
+      }
     }
   };
   
@@ -162,7 +162,7 @@ const ComparisonControls = ({
             Continuă
           </button>
         </div>
-      ) : analyzingComplete ? (
+      ) : analysisFinished ? (
         // Show the operator selection interface
         <div className="operator-selection">
           <h3>Alege simbolul de comparare:</h3>

--- a/src/components/compare/ComparisonControls.js
+++ b/src/components/compare/ComparisonControls.js
@@ -85,7 +85,8 @@ const ComparisonControls = ({
     if (currentComparison && currentComparison.result !== '=') {
       // We've found a difference, so we can stop comparing
       setAnalyzingComplete(true);
-      onNextPlaceValue(null);
+      /* eslint-disable-next-line no-undef */
+      setHighlightedPlaceValue(null);
     } else {
       // Move to the next place value
       onNextPlaceValue();

--- a/src/components/compare/ComparisonControls.js
+++ b/src/components/compare/ComparisonControls.js
@@ -79,14 +79,15 @@ const ComparisonControls = ({
   
   // Handle clicking the "Continue" button to move to next place value
   const handleContinueAnalysis = () => {
+    if (!highlightedPlaceValue) return;
+    
     // First check if this place value already determined the result
     const currentComparison = placeValueComparisons[highlightedPlaceValue];
     
     if (currentComparison && currentComparison.result !== '=') {
       // We've found a difference, so we can stop comparing
       setAnalyzingComplete(true);
-      /* eslint-disable-next-line no-undef */
-      setHighlightedPlaceValue(null);
+      onNextPlaceValue(null);
     } else {
       // Move to the next place value
       onNextPlaceValue();

--- a/src/components/compare/ComparisonFeedback.js
+++ b/src/components/compare/ComparisonFeedback.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { 
   numberToPlaceValues, 
   findDifferingPlaceValue, 
-  getPlaceValueName, 
+  getPlaceValueName,
+  getPlaceValueLabel,
   compareNumbers 
 } from '../../utils/compareNumbersUtils';
 import { PLACE_VALUES, FEEDBACK_MESSAGES } from '../../constants/compareNumbersConstants';
@@ -36,9 +37,10 @@ const ComparisonFeedback = ({ feedback, numbers }) => {
     const place1 = numberToPlaceValues(numbers[0])[firstDifferingPlace];
     const place2 = numberToPlaceValues(numbers[1])[firstDifferingPlace];
     const placeName = getPlaceValueName(firstDifferingPlace);
+    const placeLabel = getPlaceValueLabel(firstDifferingPlace);
     const correctOperator = compareNumbers(numbers[0], numbers[1]).symbol;
     
-    return `${placeName} sunt diferite: ${place1} ${place1 < place2 ? '<' : '>'} ${place2}, deci ${numbers[0]} ${correctOperator} ${numbers[1]}.`;
+    return `${placeName} (${placeLabel}) sunt diferite: ${place1} ${place1 < place2 ? '<' : '>'} ${place2}, deci ${numbers[0]} ${correctOperator} ${numbers[1]}.`;
   };
   
   // If no feedback, don't show anything

--- a/src/components/compare/ComparisonInstructions.js
+++ b/src/components/compare/ComparisonInstructions.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { getPlaceValueName } from '../../utils/compareNumbersUtils';
+import { getPlaceValueName, getPlaceValueLabel } from '../../utils/compareNumbersUtils';
 import '../../styles/ComparisonInstructions.css';
 
 /**
@@ -15,7 +15,10 @@ const ComparisonInstructions = ({ level, difficultyLevel }) => {
   // Generate instructions text based on the current difficulty level
   const getInstructionsText = () => {
     const usedPlaceValues = difficultyLevel.usedPlaceValues;
-    const placeValueNames = usedPlaceValues.map(pv => getPlaceValueName(pv));
+    // Get both the full name and shorthand label for each place value
+    const placeValueDetails = usedPlaceValues.map(pv => 
+      `${getPlaceValueName(pv)} (${getPlaceValueLabel(pv)})`
+    );
     
     // For level 1 (most basic)
     if (level <= 5) {
@@ -26,7 +29,7 @@ const ComparisonInstructions = ({ level, difficultyLevel }) => {
             <li>Abacul din stânga pentru primul număr</li>
             <li>Abacul din dreapta pentru al doilea număr</li>
           </ul>
-          <p>Apoi, compară valorile din {placeValueNames.join(' și ')} pentru a determina care număr este mai mare.</p>
+          <p>Apoi, compară valorile din {placeValueDetails.join(' și ')} pentru a determina care număr este mai mare.</p>
         </>
       );
     }
@@ -34,7 +37,7 @@ const ComparisonInstructions = ({ level, difficultyLevel }) => {
     // For higher levels
     return (
       <>
-        <p>Construiește numerele pe abacuri, apoi compară-le începând cu cea mai mare valoare de poziție ({placeValueNames[0]}):</p>
+        <p>Construiește numerele pe abacuri, apoi compară-le începând cu cea mai mare valoare de poziție ({placeValueDetails[0]}):</p>
         <ul>
           <li>Dacă valorile sunt egale, treci la următoarea poziție</li>
           <li>Dacă valorile sunt diferite, numărul cu valoarea mai mare este mai mare</li>
@@ -55,7 +58,7 @@ const ComparisonInstructions = ({ level, difficultyLevel }) => {
         </li>
         <li>
           <span className="step-number">2</span>
-          <span className="step-text">Începe cu poziția de cea mai mare valoare (Mii - M)</span>
+          <span className="step-text">Începe cu poziția de cea mai mare valoare ({getPlaceValueName(difficultyLevel.usedPlaceValues[0])} - {getPlaceValueLabel(difficultyLevel.usedPlaceValues[0])})</span>
         </li>
         <li>
           <span className="step-number">3</span>
@@ -63,7 +66,7 @@ const ComparisonInstructions = ({ level, difficultyLevel }) => {
         </li>
         <li>
           <span className="step-number">4</span>
-          <span className="step-text">Dacă valorile sunt egale, treci la următoarea poziție (Sute - S)</span>
+          <span className="step-text">Dacă valorile sunt egale, treci la următoarea poziție ({difficultyLevel.usedPlaceValues.length > 1 ? getPlaceValueName(difficultyLevel.usedPlaceValues[1]) + ' - ' + getPlaceValueLabel(difficultyLevel.usedPlaceValues[1]) : ''})</span>
         </li>
         <li>
           <span className="step-number">5</span>

--- a/src/components/compare/DualAbacusSection.js
+++ b/src/components/compare/DualAbacusSection.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import Abacus from '../abacus/Abacus';
-import { numberToPlaceValues, getPlaceValueName } from '../../utils/compareNumbersUtils';
+import CompareAbacus from './CompareAbacus';
+import { numberToPlaceValues, getPlaceValueName, getPlaceValueLabel } from '../../utils/compareNumbersUtils';
 import { PLACE_VALUES, BEAD_COLORS, FEEDBACK_MESSAGES } from '../../constants/compareNumbersConstants';
 import '../../styles/DualAbacusSection.css';
 
@@ -49,25 +49,26 @@ const DualAbacusSection = ({
       <div className="abacus-labels">
         <div className="place-value-labels">
           <div className={`place-value-label ${highlightedPlaceValue === PLACE_VALUES.THOUSANDS ? 'highlighted' : ''}`}>
-            {getPlaceValueName(PLACE_VALUES.THOUSANDS)} (M)
+            {getPlaceValueName(PLACE_VALUES.THOUSANDS)} ({getPlaceValueLabel(PLACE_VALUES.THOUSANDS)})
           </div>
           <div className={`place-value-label ${highlightedPlaceValue === PLACE_VALUES.HUNDREDS ? 'highlighted' : ''}`}>
-            {getPlaceValueName(PLACE_VALUES.HUNDREDS)} (S)
+            {getPlaceValueName(PLACE_VALUES.HUNDREDS)} ({getPlaceValueLabel(PLACE_VALUES.HUNDREDS)})
           </div>
           <div className={`place-value-label ${highlightedPlaceValue === PLACE_VALUES.TENS ? 'highlighted' : ''}`}>
-            {getPlaceValueName(PLACE_VALUES.TENS)} (Z)
+            {getPlaceValueName(PLACE_VALUES.TENS)} ({getPlaceValueLabel(PLACE_VALUES.TENS)})
           </div>
           <div className={`place-value-label ${highlightedPlaceValue === PLACE_VALUES.UNITS ? 'highlighted' : ''}`}>
-            {getPlaceValueName(PLACE_VALUES.UNITS)} (U)
+            {getPlaceValueName(PLACE_VALUES.UNITS)} ({getPlaceValueLabel(PLACE_VALUES.UNITS)})
           </div>
         </div>
       </div>
       
       <div className="abacus-container-dual">
         <div className={`abacus-wrapper ${isAbacusComplete[0] ? 'completed' : ''}`}>
-          <Abacus 
+          <CompareAbacus 
             onBeadChange={(placeValue, value) => onAbacusChange(0, placeValue, value)} 
             abacusState={abacusStates[0]}
+            showControls={false}
           />
           
           {/* Hints for first abacus */}
@@ -83,9 +84,10 @@ const DualAbacusSection = ({
         </div>
         
         <div className={`abacus-wrapper ${isAbacusComplete[1] ? 'completed' : ''}`}>
-          <Abacus 
+          <CompareAbacus 
             onBeadChange={(placeValue, value) => onAbacusChange(1, placeValue, value)} 
             abacusState={abacusStates[1]}
+            showControls={false}
           />
           
           {/* Hints for second abacus */}
@@ -111,7 +113,7 @@ const DualAbacusSection = ({
                 className="color-sample" 
                 style={{ backgroundColor: color }}
               ></div>
-              <span>{getPlaceValueName(placeValue)} ({placeValue})</span>
+              <span>{getPlaceValueName(placeValue)} ({getPlaceValueLabel(placeValue)})</span>
             </div>
           ))}
         </div>

--- a/src/components/modes/CompareNumbersMode.js
+++ b/src/components/modes/CompareNumbersMode.js
@@ -135,18 +135,14 @@ const CompareNumbersMode = () => {
     }
   };
 
-  const handleNextPlaceValueHighlight = (nextValue = undefined) => {
-    // If a specific value is provided (e.g. null), use that
-    if (nextValue !== undefined) {
-      setHighlightedPlaceValue(nextValue);
-      if (nextValue === null) {
-        // We're done with the place value comparison
-        setAnalyzingComplete(true);
-      }
+  const handleNextPlaceValueHighlight = (nextValue) => {
+    // If we receive null, we're finishing the analysis
+    if (nextValue === null) {
+      setHighlightedPlaceValue(null);
       return;
     }
     
-    // Otherwise move to the next place value in sequence
+    // Otherwise, move to the next place value in sequence
     const currentIndex = difficultyLevel.usedPlaceValues.indexOf(highlightedPlaceValue);
     if (currentIndex < difficultyLevel.usedPlaceValues.length - 1) {
       // Move to next place value
@@ -156,9 +152,6 @@ const CompareNumbersMode = () => {
       setHighlightedPlaceValue(null);
     }
   };
-
-  // Additional state for analysis completion
-  const [analyzingComplete, setAnalyzingComplete] = useState(false);
 
   return (
     <div className="compare-numbers-mode">

--- a/src/components/modes/CompareNumbersMode.js
+++ b/src/components/modes/CompareNumbersMode.js
@@ -135,8 +135,18 @@ const CompareNumbersMode = () => {
     }
   };
 
-  const handleNextPlaceValueHighlight = () => {
-    // Find current index
+  const handleNextPlaceValueHighlight = (nextValue = undefined) => {
+    // If a specific value is provided (e.g. null), use that
+    if (nextValue !== undefined) {
+      setHighlightedPlaceValue(nextValue);
+      if (nextValue === null) {
+        // We're done with the place value comparison
+        setAnalyzingComplete(true);
+      }
+      return;
+    }
+    
+    // Otherwise move to the next place value in sequence
     const currentIndex = difficultyLevel.usedPlaceValues.indexOf(highlightedPlaceValue);
     if (currentIndex < difficultyLevel.usedPlaceValues.length - 1) {
       // Move to next place value
@@ -146,6 +156,9 @@ const CompareNumbersMode = () => {
       setHighlightedPlaceValue(null);
     }
   };
+
+  // Additional state for analysis completion
+  const [analyzingComplete, setAnalyzingComplete] = useState(false);
 
   return (
     <div className="compare-numbers-mode">

--- a/src/components/modes/CompareNumbersMode.js
+++ b/src/components/modes/CompareNumbersMode.js
@@ -22,10 +22,23 @@ const CompareNumbersMode = () => {
   const { gameState, dispatch, actions } = useGameContext();
   const [numbers, setNumbers] = useState([null, null]);
   const [difficultyLevel, setDifficultyLevel] = useState(DIFFICULTY_LEVELS.LEVEL_1);
+  
+  // Initialize abacus states with the proper place value keys
   const [abacusStates, setAbacusStates] = useState([
-    { [PLACE_VALUES.THOUSANDS]: 0, [PLACE_VALUES.HUNDREDS]: 0, [PLACE_VALUES.TENS]: 0, [PLACE_VALUES.UNITS]: 0 },
-    { [PLACE_VALUES.THOUSANDS]: 0, [PLACE_VALUES.HUNDREDS]: 0, [PLACE_VALUES.TENS]: 0, [PLACE_VALUES.UNITS]: 0 }
+    { 
+      [PLACE_VALUES.THOUSANDS]: 0, 
+      [PLACE_VALUES.HUNDREDS]: 0, 
+      [PLACE_VALUES.TENS]: 0, 
+      [PLACE_VALUES.UNITS]: 0 
+    },
+    { 
+      [PLACE_VALUES.THOUSANDS]: 0, 
+      [PLACE_VALUES.HUNDREDS]: 0, 
+      [PLACE_VALUES.TENS]: 0, 
+      [PLACE_VALUES.UNITS]: 0 
+    }
   ]);
+  
   const [selectedComparisonOperator, setSelectedComparisonOperator] = useState(null);
   const [highlightedPlaceValue, setHighlightedPlaceValue] = useState(null);
   const [isComparingNow, setIsComparingNow] = useState(false);
@@ -51,10 +64,23 @@ const CompareNumbersMode = () => {
   const generateNewNumbers = () => {
     const newNumbers = generateRandomNumbers(difficultyLevel.range);
     setNumbers(newNumbers);
+    
+    // Reset the abacus states
     setAbacusStates([
-      { [PLACE_VALUES.THOUSANDS]: 0, [PLACE_VALUES.HUNDREDS]: 0, [PLACE_VALUES.TENS]: 0, [PLACE_VALUES.UNITS]: 0 },
-      { [PLACE_VALUES.THOUSANDS]: 0, [PLACE_VALUES.HUNDREDS]: 0, [PLACE_VALUES.TENS]: 0, [PLACE_VALUES.UNITS]: 0 }
+      { 
+        [PLACE_VALUES.THOUSANDS]: 0, 
+        [PLACE_VALUES.HUNDREDS]: 0, 
+        [PLACE_VALUES.TENS]: 0, 
+        [PLACE_VALUES.UNITS]: 0 
+      },
+      { 
+        [PLACE_VALUES.THOUSANDS]: 0, 
+        [PLACE_VALUES.HUNDREDS]: 0, 
+        [PLACE_VALUES.TENS]: 0, 
+        [PLACE_VALUES.UNITS]: 0 
+      }
     ]);
+    
     setSelectedComparisonOperator(null);
     setHighlightedPlaceValue(null);
     setIsComparingNow(false);
@@ -67,8 +93,12 @@ const CompareNumbersMode = () => {
   };
 
   const handleAbacusChange = (index, placeValue, value) => {
+    // Make sure value stays within limits (0-9)
+    const limitedValue = Math.max(0, Math.min(9, value));
+    
+    // Create a copy of the current states and update the specific value
     const newStates = [...abacusStates];
-    newStates[index] = { ...newStates[index], [placeValue]: value };
+    newStates[index] = { ...newStates[index], [placeValue]: limitedValue };
     setAbacusStates(newStates);
     
     // Check if abacus is correctly reflecting the number
@@ -94,7 +124,7 @@ const CompareNumbersMode = () => {
     setIsComparingNow(true);
     // Start highlighting from the highest place value
     setHighlightedPlaceValue(difficultyLevel.usedPlaceValues[0]);
-    playSound('compare-start', gameState.sound);
+    playSound('click', gameState.sound);
   };
 
   const handleComparisonOperatorSelect = (operatorSymbol) => {
@@ -135,14 +165,8 @@ const CompareNumbersMode = () => {
     }
   };
 
-  const handleNextPlaceValueHighlight = (nextValue) => {
-    // If we receive null, we're finishing the analysis
-    if (nextValue === null) {
-      setHighlightedPlaceValue(null);
-      return;
-    }
-    
-    // Otherwise, move to the next place value in sequence
+  const handleNextPlaceValueHighlight = () => {
+    // Find current index
     const currentIndex = difficultyLevel.usedPlaceValues.indexOf(highlightedPlaceValue);
     if (currentIndex < difficultyLevel.usedPlaceValues.length - 1) {
       // Move to next place value

--- a/src/constants/compareNumbersConstants.js
+++ b/src/constants/compareNumbersConstants.js
@@ -1,9 +1,17 @@
-// Romanian terms for place values
+// Romanian terms for place values (matched to match existing abacus implementation)
 export const PLACE_VALUES = {
-  THOUSANDS: 'M', // Mii
-  HUNDREDS: 'S',  // Sute
-  TENS: 'Z',      // Zeci
-  UNITS: 'U'      // Unități
+  THOUSANDS: 'thousands', // Mii
+  HUNDREDS: 'hundreds',   // Sute
+  TENS: 'tens',           // Zeci
+  UNITS: 'units'          // Unități
+};
+
+// Display labels for place values
+export const PLACE_VALUE_LABELS = {
+  [PLACE_VALUES.THOUSANDS]: 'M',
+  [PLACE_VALUES.HUNDREDS]: 'S',
+  [PLACE_VALUES.TENS]: 'Z',
+  [PLACE_VALUES.UNITS]: 'U'
 };
 
 // Romanian terms for comparison operators
@@ -43,10 +51,10 @@ export const DIFFICULTY_LEVELS = {
 
 // Color mapping for abacus beads by place value
 export const BEAD_COLORS = {
-  [PLACE_VALUES.THOUSANDS]: 'blue',
-  [PLACE_VALUES.HUNDREDS]: 'red',
-  [PLACE_VALUES.TENS]: 'green',
-  [PLACE_VALUES.UNITS]: 'purple'
+  [PLACE_VALUES.THOUSANDS]: '#3498db', // Blue
+  [PLACE_VALUES.HUNDREDS]: '#e74c3c',  // Red
+  [PLACE_VALUES.TENS]: '#2ecc71',      // Green
+  [PLACE_VALUES.UNITS]: '#9b59b6'      // Purple
 };
 
 // Romanian feedback messages

--- a/src/utils/compareNumbersUtils.js
+++ b/src/utils/compareNumbersUtils.js
@@ -1,4 +1,4 @@
-import { PLACE_VALUES, COMPARISON_OPERATORS } from '../constants/compareNumbersConstants';
+import { PLACE_VALUES, PLACE_VALUE_LABELS, COMPARISON_OPERATORS } from '../constants/compareNumbersConstants';
 
 /**
  * Generates two random numbers within a specified range
@@ -88,4 +88,13 @@ export const getPlaceValueName = (placeValue) => {
     default:
       return '';
   }
+};
+
+/**
+ * Gets the display label for a place value
+ * @param {string} placeValue - The place value key
+ * @returns {string} The display label (M, S, Z, U)
+ */
+export const getPlaceValueLabel = (placeValue) => {
+  return PLACE_VALUE_LABELS[placeValue] || '';
 };


### PR DESCRIPTION
## Fixes for "Bătălia Abacului: Compară Numerele" Feature

This PR fixes the Compare Numbers mode that wasn't functioning correctly. The main issues were related to the integration with the existing abacus component and place value naming inconsistencies.

### Main Fixes:

1. **Created a Custom Abacus Component**:
   - Added `CompareAbacus.js` that accepts state directly via props instead of using the global context
   - This allows both abacuses to have their own state

2. **Aligned Place Value Names**:
   - Updated constants to use the same place value keys as the existing abacus ('thousands', 'hundreds', 'tens', 'units')
   - Added display mapping to keep the Romanian labels ('M', 'S', 'Z', 'U') for UI display

3. **Updated Utility Functions**:
   - Added `getPlaceValueLabel()` function to get the display labels
   - Updated place value mapping in all components

4. **Fixed Component Integration**:
   - Updated all components to use the correct naming and components
   - Ensured the correct handling of abacus states

These changes should make the Compare Numbers mode fully functional while preserving the Romanian interface and educational approach described in the requirements.
